### PR TITLE
fix: async config using incorrect client token

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.3'
+
+services:
+  redis:
+    image: redis:6.2.3
+    ports:
+      - 6379:6379
+
+  redis-cluster:
+    image: grokzen/redis-cluster:5.0.12
+    ports:
+      - 7000-7005:7000-7005
+    environment:
+      REDIS_CLUSTER_IP: '0.0.0.0'
+      IP: '0.0.0.0'

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -24,7 +24,7 @@ For more configuration options, please reference the API documentation of [iored
 |---|---|---|---|
 | uri | `string` |  | URL of the redis connection. If set the `port`, `host`, `family`, and `path` will be ignored. |
 | name | `string` |  | The name of redis master. This options only available for sentinel mode. |
-| clientName | `string` | `DefaultClient` | The name of the client. Used for redis client dependency injection. |
+| connectionName | `string` | `DefaultClient` | The name of the client. Used for redis client dependency injection. |
 | cluster | `RedisClusterModuleOptions` |  | The configuration for cluster mode. |
 
 #### RedisClusterModuleOptions
@@ -62,8 +62,9 @@ import { RedisModule } from '@pokeguys/nestjs-redis';
 @Module({
   imports: [
     RedisModule.forRootAsync({
-      useFactory: () => ({
-        clientName: 'conn',
+      name: 'conn',
+      useFactory: (connectionName?: string) => ({
+        connectionName,
         uri: 'redis://localhost:6379/'
       }),
     }),

--- a/lib/interfaces/redis-module-options.interface.ts
+++ b/lib/interfaces/redis-module-options.interface.ts
@@ -8,7 +8,7 @@ export type RedisClusterModuleOptions = {
 } & Partial<ClusterOptions>;
 
 export type RedisModuleOptions = {
-  clientName?: string;
+  connectionName?: string;
   uri?: string;
   cluster?: RedisClusterModuleOptions;
   connectionFactory?: (connection: any, name: string) => any;
@@ -22,6 +22,9 @@ export interface RedisModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'>
   name?: string;
   useExisting?: Type<RedisOptionsFactory>;
   useClass?: Type<RedisOptionsFactory>;
-  useFactory?: (...args: any[]) => Promise<RedisModuleOptions> | RedisModuleOptions;
+  useFactory?: (
+    connectionName?: string,
+    ...args: any[]
+  ) => Promise<RedisModuleOptions> | RedisModuleOptions;
   inject?: any[];
 }

--- a/lib/redis-core.module.ts
+++ b/lib/redis-core.module.ts
@@ -32,7 +32,7 @@ export class RedisCoreModule implements OnApplicationShutdown {
       useValue: options,
     };
     const connectionProvider = {
-      provide: getClientToken(options.clientName),
+      provide: getClientToken(options.connectionName),
       useValue: createClient(options),
     };
     return {
@@ -60,7 +60,7 @@ export class RedisCoreModule implements OnApplicationShutdown {
   }
 
   onApplicationShutdown(): void {
-    const connection = this.moduleRef.get<Redis>(getClientToken(this.options.clientName));
+    const connection = this.moduleRef.get<Redis>(getClientToken(this.options.connectionName));
     if (connection && !this.options.keepAlive) {
       connection.disconnect();
     }
@@ -84,7 +84,7 @@ export class RedisCoreModule implements OnApplicationShutdown {
     if (options.useFactory) {
       return {
         provide: REDIS_MODULE_OPTIONS,
-        useFactory: options.useFactory,
+        useFactory: async (...args: any[]) => options.useFactory!(options.name, ...args),
         inject: options.inject || [],
       };
     }

--- a/lib/redis.module.spec.ts
+++ b/lib/redis.module.spec.ts
@@ -54,7 +54,7 @@ describe('RedisModule', () => {
       moduleRef = await Test.createTestingModule({
         imports: [
           RedisModule.forRoot({
-            clientName: 'named',
+            connectionName: 'named',
             host: 'localhost',
             port: 6379,
             keepAlive: 1000,
@@ -80,7 +80,8 @@ describe('RedisModule', () => {
             imports: [
               RedisModule.forRootAsync({
                 name: 'named',
-                useFactory: () => ({
+                useFactory: (connectionName?: string) => ({
+                  connectionName,
                   uri: 'redis://localhost:6379/',
                 }),
               }),
@@ -98,8 +99,9 @@ describe('RedisModule', () => {
 
       describe('useClass', () => {
         class RedisModuleConfigService implements RedisOptionsFactory {
-          createRedisOptions(): RedisModuleOptions {
+          createRedisOptions(connectionName?: string): RedisModuleOptions {
             return {
+              connectionName,
               uri: 'redis://localhost:6379/',
             };
           }
@@ -129,8 +131,9 @@ describe('RedisModule', () => {
       describe('useExisting', () => {
         @Injectable()
         class RedisModuleConfigService implements RedisOptionsFactory {
-          createRedisOptions(): RedisModuleOptions {
+          createRedisOptions(connectionName?: string): RedisModuleOptions {
             return {
+              connectionName,
               uri: 'redis://localhost:6379/',
             };
           }
@@ -171,13 +174,15 @@ describe('RedisModule', () => {
             imports: [
               RedisModule.forRootAsync({
                 name: 'test1',
-                useFactory: () => ({
+                useFactory: (connectionName?: string) => ({
+                  connectionName,
                   uri: 'redis://localhost:6379/',
                 }),
               }),
               RedisModule.forRootAsync({
                 name: 'test2',
-                useFactory: () => ({
+                useFactory: (connectionName?: string) => ({
+                  connectionName,
                   uri: 'redis://localhost:6379/',
                 }),
               }),


### PR DESCRIPTION
Options `useFactory`, `useExisting`, `useClass` don't respect the `name` set in `RedisModuleAsyncOptions`.

It will ignore the `options.name` and keep using the `defaultConnection` as `clientToken` to close the connection. When the application is shutting down, it causes unexpected exceptions.